### PR TITLE
NEW Support for other authenticators

### DIFF
--- a/code/BasicRestfulAuthenticator.php
+++ b/code/BasicRestfulAuthenticator.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * A simple authenticator for the Restful server.
+ *
+ * This allows users to be authenticated against that RestfulServer using their
+ * login details, however they will be passed 'in the open' and will require the
+ * application accessing the RestfulServer to store logins in plain text (or in
+ * decrytable form)
+ */
+class BasicRestfulAuthenticator  {
+
+	/**
+	 * The authenticate function
+	 *
+	 * Takes the basic auth details and attempts to log a user in from the DB
+	 *
+	 * @return Member|false The Member object, or false if no member
+	 */
+	public static function authenticate() {
+		//if there is no username or password, break
+		if(!isset($_SERVER['PHP_AUTH_USER']) || !isset($_SERVER['PHP_AUTH_PW'])) return false;
+
+		//Attempt to authenticate with the default authenticator for the site
+		$authClass = Authenticator::get_default_authenticator();
+		$member = $authClass::authenticate(array(
+			'Email' => $_SERVER['PHP_AUTH_USER'],
+			'Password' => $_SERVER['PHP_AUTH_PW'],
+		));
+
+		//Log the member in and return the member, if they were found
+		if($member) {
+			$member->LogIn(false);
+			return $member;
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
I've added the ability to add other authenticators to the RestfulServer

Use the config system to change the authenticator option and it'll call
`authenticate` on that class.

I've assumed that one won't need any parameters sent to that and
everything can be taken from `Controller::curr()->request`

This relies on the default authenticator being able to accept the
standard email/password identifiers. I imagine anyone using a default
authenticator to that will go to the trouble of adding a RestfulServer
authenticator too.
