### PR TITLE
Ensure that we can GET has_many relations

### DIFF
--- a/code/RestfulServer.php
+++ b/code/RestfulServer.php
@@ -509,9 +509,9 @@ class RestfulServer extends Controller {
 	protected function getObjectRelationQuery($obj, $params, $sort, $limit, $relationName) {
 		// The relation method will return a DataList, that getSearchQuery subsequently manipulates
 		if($obj->hasMethod($relationName)) {
-			if($relationClass = $obj->has_one($relationName)) {
-				$joinField = $relationName . 'ID';
-				$list = DataList::create($relationClass)->byIDs(array($obj->$joinField));
+			if($obj->has_one($relationName) || $obj->has_many($relationName)) {
+				$relationClass = $obj->has_one($relationName) ? $obj->has_one($relationName) : $obj->has_many($relationName);
+				$list = DataList::create($obj->ClassName)->relation($relationName)->forForeignID(array($obj->ID));
 			} else {
 				$list = $obj->$relationName();
 			}


### PR DESCRIPTION
Augmented RestfulServer.php so that it's possible GET has_many relationships.

For example, ProposalPage (ID 5286) has_many ProposalEvents:

    private static $has_many = array(
        'ProposalEvents' => 'ProposalEvent'
    );

We want to be able to surface these via a restfulserver API call, e.g.:

http://localhost.cwp/api/v1/ProposalPage/5286/ProposalEvents.json