### PR TITLE
FIX getFieldsForObj does not return relation classes in hasField() check

### DIFF
--- a/src/DataFormatter.php
+++ b/src/DataFormatter.php
@@ -301,7 +301,9 @@ abstract class DataFormatter
         if (is_array($this->customFields)) {
             foreach ($this->customFields as $fieldName) {
                 // @todo Possible security risk by making methods accessible - implement field-level security
-                if ($obj->hasField($fieldName) || $obj->hasMethod("get{$fieldName}")) {
+                if (($obj->hasField($fieldName) && !is_object($obj->getField($fieldName)))
+                    || $obj->hasMethod("get{$fieldName}")
+                ) {
                     $dbFields[$fieldName] = $fieldName;
                 }
             }

--- a/tests/unit/Stubs/RestfulServerTestAuthor.php
+++ b/tests/unit/Stubs/RestfulServerTestAuthor.php
@@ -2,11 +2,8 @@
 
 namespace SilverStripe\RestfulServer\Tests\Stubs;
 
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestPage;
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestAuthor;
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestAuthorRating;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 
 class RestfulServerTestAuthor extends DataObject implements TestOnly
 {

--- a/tests/unit/Stubs/RestfulServerTestAuthorRating.php
+++ b/tests/unit/Stubs/RestfulServerTestAuthorRating.php
@@ -2,9 +2,8 @@
 
 namespace SilverStripe\RestfulServer\Tests\Stubs;
 
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestAuthor;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 
 class RestfulServerTestAuthorRating extends DataObject implements TestOnly
 {

--- a/tests/unit/Stubs/RestfulServerTestComment.php
+++ b/tests/unit/Stubs/RestfulServerTestComment.php
@@ -2,12 +2,10 @@
 
 namespace SilverStripe\RestfulServer\Tests\Stubs;
 
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestPage;
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestAuthor;
-use SilverStripe\Security\Permission;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
 
 /**
  * Everybody can view comments, logged in members in the "users" group can create comments,

--- a/tests/unit/Stubs/RestfulServerTestPage.php
+++ b/tests/unit/Stubs/RestfulServerTestPage.php
@@ -2,10 +2,8 @@
 
 namespace SilverStripe\RestfulServer\Tests\Stubs;
 
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestAuthor;
-use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestComment;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 
 class RestfulServerTestPage extends DataObject implements TestOnly
 {

--- a/tests/unit/Stubs/RestfulServerTestSecretThing.php
+++ b/tests/unit/Stubs/RestfulServerTestSecretThing.php
@@ -2,9 +2,9 @@
 
 namespace SilverStripe\RestfulServer\Tests\Stubs;
 
-use SilverStripe\Security\Permission;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 
 class RestfulServerTestSecretThing extends DataObject implements TestOnly, PermissionProvider


### PR DESCRIPTION
Relations e.g. `$obj->Author` can now return the relation class in 4.1. The change to `DataObject::getField` in this commit: https://github.com/silverstripe/silverstripe-framework/commit/db9aa2c5c7be75cfdf1a803c77e6c74d151163b0 no longer checks if the relation is an object, so this PR is adding that check back in so the change it backwards compatible from 4.0 and higher.

Fixes #48 