### PR TITLE
Added general Exception catch/response. Added extension points to response methods

### DIFF
--- a/tests/unit/RestfulServerTest.php
+++ b/tests/unit/RestfulServerTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\RestfulServer\Tests;
 
 use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestComment;
+use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestExceptionThrown;
 use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestSecretThing;
 use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestPage;
 use SilverStripe\RestfulServer\Tests\Stubs\RestfulServerTestAuthor;
@@ -37,6 +38,8 @@ class RestfulServerTest extends SapphireTest
         RestfulServerTestPage::class,
         RestfulServerTestAuthor::class,
         RestfulServerTestAuthorRating::class,
+        RestfulServerTestValidationFailure::class,
+        RestfulServerTestExceptionThrown::class,
     ];
 
     protected function urlSafeClassname($classname)
@@ -585,5 +588,18 @@ class RestfulServerTest extends SapphireTest
         // Assumption: XML is default output
         $responseArr = Convert::xml2array($response->getBody());
         $this->assertEquals('SilverStripe\\ORM\\ValidationException', $responseArr['type']);
+    }
+
+    public function testExceptionThrownWithPOST()
+    {
+        $urlSafeClassname = $this->urlSafeClassname(RestfulServerTestExceptionThrown::class);
+        $url = "{$this->baseURI}/api/v1/$urlSafeClassname/";
+        $data = [
+            'Content' => 'Test',
+        ];
+        $response = Director::test($url, $data, null, 'POST');
+        // Assumption: XML is default output
+        $responseArr = Convert::xml2array($response->getBody());
+        $this->assertEquals(\Exception::class, $responseArr['type']);
     }
 }

--- a/tests/unit/Stubs/RestfulServerTestExceptionThrown.php
+++ b/tests/unit/Stubs/RestfulServerTestExceptionThrown.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SilverStripe\RestfulServer\Tests\Stubs;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Class RestfulServerTestExceptionThrown
+ * @package SilverStripe\RestfulServer\Tests\Stubs
+ *
+ * @property string Content
+ * @property string Title
+ */
+class RestfulServerTestExceptionThrown extends DataObject implements TestOnly
+{
+    private static $api_access = true;
+
+    private static $table_name = 'RestfulServerTestExceptionThrown';
+
+    private static $db = array(
+        'Content' => 'Text',
+        'Title' => 'Text',
+    );
+
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        throw new \Exception('This is an exception test');
+    }
+
+    public function canView($member = null)
+    {
+        return true;
+    }
+
+    public function canEdit($member = null)
+    {
+        return true;
+    }
+
+    public function canDelete($member = null)
+    {
+        return true;
+    }
+
+    public function canCreate($member = null, $context = array())
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
I added extension points because I didn't want to assume that **everyone** would want to put a full trace into their `Exception` response, but for our particular usage of the module, a trace is safe and useful. I figured while I was there, it wouldn't hurt to add extension points to the other response methods.