### PR TITLE
Add field mapping config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,44 @@ class Article extends DataObject {
 }
 ```
 
+Example DataObject field mapping, allows aliasing fields so that public requests and responses display different field names:
+
+```php
+namespace Vendor\Project;
+
+use SilverStripe\ORM\DataObject;
+
+class Article extends DataObject {
+
+    private static $db = [
+        'Title'=>'Text',
+        'Published'=>'Boolean'
+    ];
+
+    private static $api_access = [
+        'view' => ['Title', 'Content'],
+    ];
+
+    private static $api_field_mapping = [
+        'customTitle' => 'Title',
+    ];
+}
+```
+Given a dataobject with values:
+```yml
+    ID: 12
+    Title: Title Value
+    Content: Content value
+```
+which when requesting with the url `/api/v1/Vendor-Project-Article/12?fields=customTitle,Content` and `Accept: application/json` the response will look like:
+```Javascript
+{
+    "customTitle": "Title Value",
+    "Content": "Content value"
+}
+```
+Similarly, `PUT` or `POST` requests will have fields transformed from the alias name to the DB field name.
+
 ## Supported operations
 
  - `GET /api/v1/(ClassName)/(ID)` - gets a database record

--- a/src/DataFormatter.php
+++ b/src/DataFormatter.php
@@ -356,4 +356,87 @@ abstract class DataFormatter
     {
         user_error('DataFormatter::convertStringToArray not implemented on subclass', E_USER_ERROR);
     }
+
+    /**
+     * Convert an array of aliased field names to their Dataobject field name
+     *
+     * @param string $className
+     * @param string[] $fields
+     * @return string[]
+     */
+    public function getRealFields($className, $fields)
+    {
+        $apiMapping = Config::inst()->get($className, 'api_field_mapping');
+        if (is_array($apiMapping) && is_array($fields)) {
+            $mappedFields = [];
+            foreach ($fields as $field) {
+                $mappedFields[] = $this->getMappedKey($apiMapping, $field);
+            }
+            return $mappedFields;
+        }
+        return $fields;
+    }
+
+    /**
+     * Get the DataObject field name from its alias
+     *
+     * @param string $className
+     * @param string $field
+     * @return string
+     */
+    public function getRealFieldName($className, $field)
+    {
+        $apiMapping = $this->getApiMapping($className);
+        return $this->getMappedKey($apiMapping, $field);
+    }
+
+    /**
+     * Get a DataObject Field's Alias
+     * defaults to the fieldname
+     *
+     * @param string $className
+     * @param string $field
+     * @return string
+     */
+    public function getFieldAlias($className, $field)
+    {
+        $apiMapping = $this->getApiMapping($className);
+        $apiMapping = array_flip($apiMapping);
+        return $this->getMappedKey($apiMapping, $field);
+    }
+
+    /**
+     * Get the 'api_field_mapping' config value for a class
+     * or return an empty array
+     *
+     * @param string $className
+     * @return string[]|array
+     */
+    protected function getApiMapping($className)
+    {
+        $apiMapping = Config::inst()->get($className, 'api_field_mapping');
+        if ($apiMapping && is_array($apiMapping)) {
+            return $apiMapping;
+        }
+        return [];
+    }
+
+    /**
+     * Helper function to get mapped field names
+     *
+     * @param array $map
+     * @param string $key
+     * @return string
+     */
+    protected function getMappedKey($map, $key)
+    {
+        if (is_array($map)) {
+            if (array_key_exists($key, $map)) {
+                return $map[$key];
+            } else {
+                return $key;
+            }
+        }
+        return $key;
+    }
 }

--- a/src/DataFormatter.php
+++ b/src/DataFormatter.php
@@ -366,7 +366,7 @@ abstract class DataFormatter
      */
     public function getRealFields($className, $fields)
     {
-        $apiMapping = Config::inst()->get($className, 'api_field_mapping');
+        $apiMapping = $this->getApiMapping($className);
         if (is_array($apiMapping) && is_array($fields)) {
             $mappedFields = [];
             foreach ($fields as $field) {

--- a/src/DataFormatter/JSONDataFormatter.php
+++ b/src/DataFormatter/JSONDataFormatter.php
@@ -74,7 +74,8 @@ class JSONDataFormatter extends DataFormatter
             }
 
             $fieldValue = $obj->obj($fieldName)->forTemplate();
-            $serobj->$fieldName = $fieldValue;
+            $mappedFieldName = $this->getFieldAlias($className, $fieldName);
+            $serobj->$mappedFieldName = $fieldValue;
         }
 
         if ($this->relationDepth > 0) {

--- a/src/DataFormatter/XMLDataFormatter.php
+++ b/src/DataFormatter/XMLDataFormatter.php
@@ -82,7 +82,8 @@ class XMLDataFormatter extends DataFormatter
                 } else {
                     $fieldValue = Convert::raw2xml($fieldValue);
                 }
-                $xml .= "<$fieldName>$fieldValue</$fieldName>\n";
+                $mappedFieldName = $this->getFieldAlias(get_class($obj), $fieldName);
+                $xml .= "<$mappedFieldName>$fieldValue</$mappedFieldName>\n";
             }
         }
 

--- a/src/RestfulServer.php
+++ b/src/RestfulServer.php
@@ -13,7 +13,6 @@ use SilverStripe\ORM\SS_List;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\CMS\Model\SiteTree;
-use TractorCow\Fluent\Task\ConvertTranslatableTask\Exception;
 
 /**
  * Generic RESTful server, which handles webservice access to arbitrary DataObjects.

--- a/tests/unit/RestfulServerTest.php
+++ b/tests/unit/RestfulServerTest.php
@@ -16,6 +16,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\RestfulServer\DataFormatter\JSONDataFormatter;
 use Page;
+use SilverStripe\Core\Config\Config;
 
 /**
  *
@@ -112,6 +113,18 @@ class RestfulServerTest extends SapphireTest
         unset($_SERVER['PHP_AUTH_PW']);
     }
 
+    public function testGETWithFieldAlias()
+    {
+        Config::inst()->set(RestfulServerTestAuthorRating::class, 'api_field_mapping', ['rate' => 'Rating']);
+        $rating1 = $this->objFromFixture(RestfulServerTestAuthorRating::class, 'rating1');
+
+        $urlSafeClassname = $this->urlSafeClassname(RestfulServerTestAuthorRating::class);
+        $url = "{$this->baseURI}/api/v1/$urlSafeClassname/" . $rating1->ID;
+        $response = Director::test($url, null, null, 'GET');
+        $responseArr = Convert::xml2array($response->getBody());
+        $this->assertEquals(3, $responseArr['rate']);
+    }
+
     public function testAuthenticatedPUT()
     {
         $comment1 = $this->objFromFixture(RestfulServerTestComment::class, 'comment1');
@@ -157,6 +170,28 @@ class RestfulServerTest extends SapphireTest
         );
         $this->assertContains($rating1->ID, $ratingIDs);
         $this->assertContains($rating2->ID, $ratingIDs);
+    }
+
+    public function testGETRelationshipsWithAlias()
+    {
+        // Alias do not currently work with Relationships
+        Config::inst()->set(RestfulServerTestAuthor::class, 'api_field_mapping', ['stars' => 'Ratings']);
+        $author1 = $this->objFromFixture(RestfulServerTestAuthor::class, 'author1');
+        $rating1 = $this->objFromFixture(RestfulServerTestAuthorRating::class, 'rating1');
+
+        // @todo should be set up by fixtures, doesn't work for some reason...
+        $author1->Ratings()->add($rating1);
+
+        $urlSafeClassname = $this->urlSafeClassname(RestfulServerTestAuthor::class);
+        $url = "{$this->baseURI}/api/v1/$urlSafeClassname/" . $author1->ID . '?add_fields=stars';
+        $response = Director::test($url, null, null, 'GET');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $responseArr = Convert::xml2array($response->getBody());
+        $xmlTagSafeClassName = $this->urlSafeClassname(RestfulServerTestAuthorRating::class);
+
+        $this->assertTrue(array_key_exists('Ratings', $responseArr));
+        $this->assertFalse(array_key_exists('stars', $responseArr));
     }
 
     public function testGETManyManyRelationshipsXML()
@@ -394,6 +429,17 @@ class RestfulServerTest extends SapphireTest
         $this->assertContains('<Rating>' . $rating1->Rating . '</Rating>', $response->getBody());
     }
 
+    public function testXMLValueFormattingWithFieldAlias()
+    {
+        Config::inst()->set(RestfulServerTestAuthorRating::class, 'api_field_mapping', ['rate' => 'Rating']);
+        $rating1 = $this->objFromFixture(RestfulServerTestAuthorRating::class, 'rating1');
+
+        $urlSafeClassname = $this->urlSafeClassname(RestfulServerTestAuthorRating::class);
+        $url = "{$this->baseURI}/api/v1/$urlSafeClassname/" . $rating1->ID;
+        $response = Director::test($url, null, null, 'GET');
+        $this->assertContains('<rate>' . $rating1->Rating . '</rate>', $response->getBody());
+    }
+
     public function testApiAccessFieldRestrictions()
     {
         $author1 = $this->objFromFixture(RestfulServerTestAuthor::class, 'author1');
@@ -499,6 +545,23 @@ class RestfulServerTest extends SapphireTest
         $this->assertNotEquals('haxx0red', $responseArr['WriteProtectedField']);
     }
 
+    public function testFieldAliasWithPUT()
+    {
+        Config::inst()->set(RestfulServerTestAuthorRating::class, 'api_field_mapping', ['rate' => 'Rating']);
+        $rating1 = $this->objFromFixture(RestfulServerTestAuthorRating::class, 'rating1');
+        $urlSafeClassname = $this->urlSafeClassname(RestfulServerTestAuthorRating::class);
+        $url = "{$this->baseURI}/api/v1/$urlSafeClassname/" . $rating1->ID;
+        // Test input with original fieldname
+        $data = array(
+            'Rating' => '42',
+        );
+        $response = Director::test($url, $data, null, 'PUT');
+        // Assumption: XML is default output
+        $responseArr = Convert::xml2array($response->getBody());
+        // should output with aliased name
+        $this->assertEquals(42, $responseArr['rate']);
+    }
+
     public function testJSONDataFormatter()
     {
         $formatter = new JSONDataFormatter();
@@ -526,6 +589,29 @@ class RestfulServerTest extends SapphireTest
         );
     }
 
+    public function testJSONDataFormatterWithFieldAlias()
+    {
+        Config::inst()->set(Member::class, 'api_field_mapping', ['MyName' => 'FirstName']);
+        $formatter = new JSONDataFormatter();
+        $editor = $this->objFromFixture(Member::class, 'editor');
+        $user = $this->objFromFixture(Member::class, 'user');
+
+        // The DataFormatter performs canView calls
+        // these are `Member`s so we need to be ADMIN types
+        $this->logInWithPermission('ADMIN');
+
+        $set = Member::get()
+            ->filter('ID', [$editor->ID, $user->ID])
+            ->sort('"Email" ASC'); // for sorting for postgres
+
+        $this->assertEquals(
+            '{"totalSize":null,"items":[{"MyName":"Editor","Email":"editor@test.com"},' .
+                '{"MyName":"User","Email":"user@test.com"}]}',
+            $formatter->convertDataObjectSet($set, ["FirstName", "Email"]),
+            "Correct JSON formatting with field alias"
+        );
+    }
+
     public function testApiAccessWithPOST()
     {
         $urlSafeClassname = $this->urlSafeClassname(RestfulServerTestAuthorRating::class);
@@ -539,6 +625,19 @@ class RestfulServerTest extends SapphireTest
         $responseArr = Convert::xml2array($response->getBody());
         $this->assertEquals(42, $responseArr['Rating']);
         $this->assertNotEquals('haxx0red', $responseArr['WriteProtectedField']);
+    }
+
+    public function testFieldAliasWithPOST()
+    {
+        Config::inst()->set(RestfulServerTestAuthorRating::class, 'api_field_mapping', ['rate' => 'Rating']);
+        $urlSafeClassname = $this->urlSafeClassname(RestfulServerTestAuthorRating::class);
+        $url = "{$this->baseURI}/api/v1/$urlSafeClassname/";
+        $data = [
+            'rate' => '42',
+        ];
+        $response = Director::test($url, $data, null, 'POST');
+        $responseArr = Convert::xml2array($response->getBody());
+        $this->assertEquals(42, $responseArr['rate']);
     }
 
     public function testCanViewRespectedInList()


### PR DESCRIPTION
This adds the ability to define aliases that map client-facing fields to internal field names or map existing field names to different names.

A new config variable `api_field_mapping` has been added that takes an array of the shape:
```php
[
  'fieldAlias' => 'DataObjectFieldName',
];
```

And mapping has been added to the handers and formatters. 

Feedback is much appreciated.
