### PR TITLE
FIX: make RestfulServer:: configurable

### DIFF
--- a/src/RestfulServer.php
+++ b/src/RestfulServer.php
@@ -331,15 +331,15 @@ class RestfulServer extends Controller
         // get formatter
         if (!empty($extension)) {
             $formatter = DataFormatter::for_extension($extension);
-        } elseif ($includeAcceptHeader && !empty($accept) && $accept != '*/*') {
+        } elseif ($includeAcceptHeader && !empty($accept) && strpos($accept, '*/*') === false) {
             $formatter = DataFormatter::for_mimetypes($mimetypes);
             if (!$formatter) {
-                $formatter = DataFormatter::for_extension(self::$default_extension);
+                $formatter = DataFormatter::for_extension($this->config()->default_extension);
             }
         } elseif (!empty($contentType)) {
             $formatter = DataFormatter::for_mimetype($contentType);
         } else {
-            $formatter = DataFormatter::for_extension(self::$default_extension);
+            $formatter = DataFormatter::for_extension($this->config()->default_extension);
         }
 
         if (!$formatter) {


### PR DESCRIPTION
There is no way to change the default format currently, because the private static is used directly instead of the distilled configuration value.