### PR TITLE
Sanitise json classnames

### DIFF
--- a/src/DataFormatter/JSONDataFormatter.php
+++ b/src/DataFormatter/JSONDataFormatter.php
@@ -108,11 +108,11 @@ class JSONDataFormatter extends DataFormatter
                 }
 
                 $fieldName = $relName . 'ID';
-                if ($obj->$fieldName) {
-                    $href = Director::absoluteURL($this->config()->api_base . "$relClass/" . $obj->$fieldName);
-                } else {
-                    $href = Director::absoluteURL($this->config()->api_base . "$className/$id/$relName");
-                }
+                $rel = $this->config()->api_base;
+                $rel .= $obj->$fieldName
+                    ? $this->sanitiseClassName($relClass) . '/' . $obj->$fieldName
+                    : $this->sanitiseClassName($className) . "/$id/$relName";
+                $href = Director::absoluteURL($rel);
                 $serobj->$relName = ArrayData::array_to_object(array(
                     "className" => $relClass,
                     "href" => "$href.json",
@@ -140,8 +140,8 @@ class JSONDataFormatter extends DataFormatter
                 $innerParts = array();
                 $items = $obj->$relName();
                 foreach ($items as $item) {
-                    //$href = Director::absoluteURL($this->config()->api_base . "$className/$id/$relName/$item->ID");
-                    $href = Director::absoluteURL($this->config()->api_base . "$relClass/$item->ID");
+                    $rel = $this->config()->api_base . $this->sanitiseClassName($relClass) . "/$item->ID";
+                    $href = Director::absoluteURL($rel);
                     $innerParts[] = ArrayData::array_to_object(array(
                         "className" => $relClass,
                         "href" => "$href.json",

--- a/src/RestfulServer.php
+++ b/src/RestfulServer.php
@@ -331,15 +331,15 @@ class RestfulServer extends Controller
         // get formatter
         if (!empty($extension)) {
             $formatter = DataFormatter::for_extension($extension);
-        } elseif ($includeAcceptHeader && !empty($accept) && $accept != '*/*') {
+        } elseif ($includeAcceptHeader && !empty($accept) && strpos($accept, '*/*') === false) {
             $formatter = DataFormatter::for_mimetypes($mimetypes);
             if (!$formatter) {
-                $formatter = DataFormatter::for_extension(self::$default_extension);
+                $formatter = DataFormatter::for_extension($this->config()->default_extension);
             }
         } elseif (!empty($contentType)) {
             $formatter = DataFormatter::for_mimetype($contentType);
         } else {
-            $formatter = DataFormatter::for_extension(self::$default_extension);
+            $formatter = DataFormatter::for_extension($this->config()->default_extension);
         }
 
         if (!$formatter) {


### PR DESCRIPTION
The JSON formatter doesn't clean up the class names, so all the hrefs to relations are broken.

(Unfortunately I messed up this request by not creating a fix branch for my other request)