### PR TITLE
FIX: add missing canView check in json

### DIFF
--- a/src/DataFormatter/JSONDataFormatter.php
+++ b/src/DataFormatter/JSONDataFormatter.php
@@ -143,7 +143,9 @@ class JSONDataFormatter extends DataFormatter
                 $innerParts = array();
                 $items = $obj->$relName();
                 foreach ($items as $item) {
-                    if (!$item->canView()) continue;
+                    if (!$item->canView()) {
+                        continue;
+                    }
                     $rel = $this->config()->api_base . $this->sanitiseClassName($relClass) . "/$item->ID";
                     $href = Director::absoluteURL($rel);
                     $innerParts[] = ArrayData::array_to_object(array(

--- a/src/DataFormatter/JSONDataFormatter.php
+++ b/src/DataFormatter/JSONDataFormatter.php
@@ -106,6 +106,9 @@ class JSONDataFormatter extends DataFormatter
                 if ($this->customRelations && !in_array($relName, $this->customRelations)) {
                     continue;
                 }
+                if ($obj->$relName() && (!$obj->$relName()->exists() || !$obj->$relName()->canView())) {
+                    continue;
+                }
 
                 $fieldName = $relName . 'ID';
                 $rel = $this->config()->api_base;
@@ -140,6 +143,7 @@ class JSONDataFormatter extends DataFormatter
                 $innerParts = array();
                 $items = $obj->$relName();
                 foreach ($items as $item) {
+                    if (!$item->canView()) continue;
                     $rel = $this->config()->api_base . $this->sanitiseClassName($relClass) . "/$item->ID";
                     $href = Director::absoluteURL($rel);
                     $innerParts[] = ArrayData::array_to_object(array(


### PR DESCRIPTION
Currently the JSON formatted DataLists show non-existent hasOnes and related objects, that the user !canView.