### PR TITLE
FIX: fix JSONDataFormatter to not convert values to XML

### DIFF
--- a/src/DataFormatter/JSONDataFormatter.php
+++ b/src/DataFormatter/JSONDataFormatter.php
@@ -89,7 +89,7 @@ class JSONDataFormatter extends DataFormatter
                 continue;
             }
 
-            $fieldValue = $obj->obj($fieldName)->forTemplate();
+            $fieldValue = $obj->obj($fieldName)->RAW();
             $mappedFieldName = $this->getFieldAlias($className, $fieldName);
             $serobj->$mappedFieldName = $fieldValue;
         }


### PR DESCRIPTION
JSONDataFormatter::convertDataObjectToJSONObject() uses DBField::forTemplate() which under the hood translates to Convert::raw2XML(), which in turn leads to all values being html encoded. Obviously this is not desirable for the JSON data type.