### PR TITLE
Fix infinite redirect after PUT

### DIFF
--- a/src/RestfulServer.php
+++ b/src/RestfulServer.php
@@ -489,7 +489,7 @@ class RestfulServer extends Controller
             return $obj;
         }
 
-        $this->getResponse()->setStatusCode(303); // See Other
+        $this->getResponse()->setStatusCode(202); // Accepted
         $this->getResponse()->addHeader('Content-Type', $responseFormatter->getOutputContentType());
 
         // Append the default extension for the output format to the Location header

--- a/src/RestfulServer.php
+++ b/src/RestfulServer.php
@@ -489,7 +489,7 @@ class RestfulServer extends Controller
             return $obj;
         }
 
-        $this->getResponse()->setStatusCode(200); // Success
+        $this->getResponse()->setStatusCode(303); // Success
         $this->getResponse()->addHeader('Content-Type', $responseFormatter->getOutputContentType());
 
         // Append the default extension for the output format to the Location header

--- a/src/RestfulServer.php
+++ b/src/RestfulServer.php
@@ -489,7 +489,7 @@ class RestfulServer extends Controller
             return $obj;
         }
 
-        $this->getResponse()->setStatusCode(303); // Success
+        $this->getResponse()->setStatusCode(303); // See Other
         $this->getResponse()->addHeader('Content-Type', $responseFormatter->getOutputContentType());
 
         // Append the default extension for the output format to the Location header

--- a/tests/unit/RestfulServerTest.php
+++ b/tests/unit/RestfulServerTest.php
@@ -144,7 +144,7 @@ class RestfulServerTest extends SapphireTest
         $_SERVER['PHP_AUTH_USER'] = 'editor@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'editor';
         $response = Director::test($url, $data, null, 'PUT');
-        $this->assertEquals(303, $response->getStatusCode()); // See Other
+        $this->assertEquals(202, $response->getStatusCode()); // Accepted
 
         unset($_SERVER['PHP_AUTH_USER']);
         unset($_SERVER['PHP_AUTH_PW']);
@@ -237,7 +237,7 @@ class RestfulServerTest extends SapphireTest
             'Content-Type' => 'application/x-www-form-urlencoded'
         );
         $response = Director::test($url, null, null, 'PUT', $body, $headers);
-        $this->assertEquals(303, $response->getStatusCode()); // See Other
+        $this->assertEquals(202, $response->getStatusCode()); // Accepted
         // Assumption: XML is default output
         $responseArr = Convert::xml2array($response->getBody());
         $this->assertEquals($comment1->ID, $responseArr['ID']);
@@ -306,7 +306,7 @@ class RestfulServerTest extends SapphireTest
             'Content-Type'=>'application/json',
             'Accept' => 'application/json'
         ));
-        $this->assertEquals(303, $response->getStatusCode()); // See Other
+        $this->assertEquals(202, $response->getStatusCode()); // Accepted
         $obj = Convert::json2obj($response->getBody());
         $this->assertEquals($comment1->ID, $obj->ID);
         $this->assertEquals('updated', $obj->Comment);
@@ -316,7 +316,7 @@ class RestfulServerTest extends SapphireTest
         $url = "{$this->baseURI}/api/v1/$urlSafeClassname/{$comment1->ID}.json";
         $body = '{"Comment":"updated"}';
         $response = Director::test($url, null, null, 'PUT', $body);
-        $this->assertEquals(303, $response->getStatusCode()); // See Other
+        $this->assertEquals(202, $response->getStatusCode()); // Accepted
         $this->assertEquals($url, $response->getHeader('Location'));
         $obj = Convert::json2obj($response->getBody());
         $this->assertEquals($comment1->ID, $obj->ID);
@@ -338,7 +338,7 @@ class RestfulServerTest extends SapphireTest
         $url = "{$this->baseURI}/api/v1/$urlSafeClassname/" . $comment1->ID;
         $body = '<RestfulServerTestComment><Comment>updated</Comment></RestfulServerTestComment>';
         $response = Director::test($url, null, null, 'PUT', $body, array('Content-Type'=>'text/xml'));
-        $this->assertEquals(303, $response->getStatusCode()); // See Other
+        $this->assertEquals(202, $response->getStatusCode()); // Accepted
         $obj = Convert::xml2array($response->getBody());
         $this->assertEquals($comment1->ID, $obj['ID']);
         $this->assertEquals('updated', $obj['Comment']);
@@ -348,7 +348,7 @@ class RestfulServerTest extends SapphireTest
         $url = "{$this->baseURI}/api/v1/$urlSafeClassname/{$comment1->ID}.xml";
         $body = '<RestfulServerTestComment><Comment>updated</Comment></RestfulServerTestComment>';
         $response = Director::test($url, null, null, 'PUT', $body);
-        $this->assertEquals(303, $response->getStatusCode()); // See Other
+        $this->assertEquals(202, $response->getStatusCode()); // Accepted
         $this->assertEquals($url, $response->getHeader('Location'));
         $obj = Convert::xml2array($response->getBody());
         $this->assertEquals($comment1->ID, $obj['ID']);

--- a/tests/unit/RestfulServerTest.php
+++ b/tests/unit/RestfulServerTest.php
@@ -144,7 +144,7 @@ class RestfulServerTest extends SapphireTest
         $_SERVER['PHP_AUTH_USER'] = 'editor@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'editor';
         $response = Director::test($url, $data, null, 'PUT');
-        $this->assertEquals(200, $response->getStatusCode()); // Success
+        $this->assertEquals(303, $response->getStatusCode()); // See Other
 
         unset($_SERVER['PHP_AUTH_USER']);
         unset($_SERVER['PHP_AUTH_PW']);
@@ -237,7 +237,7 @@ class RestfulServerTest extends SapphireTest
             'Content-Type' => 'application/x-www-form-urlencoded'
         );
         $response = Director::test($url, null, null, 'PUT', $body, $headers);
-        $this->assertEquals(200, $response->getStatusCode()); // Success
+        $this->assertEquals(303, $response->getStatusCode()); // See Other
         // Assumption: XML is default output
         $responseArr = Convert::xml2array($response->getBody());
         $this->assertEquals($comment1->ID, $responseArr['ID']);
@@ -306,7 +306,7 @@ class RestfulServerTest extends SapphireTest
             'Content-Type'=>'application/json',
             'Accept' => 'application/json'
         ));
-        $this->assertEquals(200, $response->getStatusCode()); // Updated
+        $this->assertEquals(303, $response->getStatusCode()); // See Other
         $obj = Convert::json2obj($response->getBody());
         $this->assertEquals($comment1->ID, $obj->ID);
         $this->assertEquals('updated', $obj->Comment);
@@ -316,7 +316,7 @@ class RestfulServerTest extends SapphireTest
         $url = "{$this->baseURI}/api/v1/$urlSafeClassname/{$comment1->ID}.json";
         $body = '{"Comment":"updated"}';
         $response = Director::test($url, null, null, 'PUT', $body);
-        $this->assertEquals(200, $response->getStatusCode()); // Updated
+        $this->assertEquals(303, $response->getStatusCode()); // See Other
         $this->assertEquals($url, $response->getHeader('Location'));
         $obj = Convert::json2obj($response->getBody());
         $this->assertEquals($comment1->ID, $obj->ID);
@@ -338,7 +338,7 @@ class RestfulServerTest extends SapphireTest
         $url = "{$this->baseURI}/api/v1/$urlSafeClassname/" . $comment1->ID;
         $body = '<RestfulServerTestComment><Comment>updated</Comment></RestfulServerTestComment>';
         $response = Director::test($url, null, null, 'PUT', $body, array('Content-Type'=>'text/xml'));
-        $this->assertEquals(200, $response->getStatusCode()); // Updated
+        $this->assertEquals(303, $response->getStatusCode()); // See Other
         $obj = Convert::xml2array($response->getBody());
         $this->assertEquals($comment1->ID, $obj['ID']);
         $this->assertEquals('updated', $obj['Comment']);
@@ -348,7 +348,7 @@ class RestfulServerTest extends SapphireTest
         $url = "{$this->baseURI}/api/v1/$urlSafeClassname/{$comment1->ID}.xml";
         $body = '<RestfulServerTestComment><Comment>updated</Comment></RestfulServerTestComment>';
         $response = Director::test($url, null, null, 'PUT', $body);
-        $this->assertEquals(200, $response->getStatusCode()); // Updated
+        $this->assertEquals(303, $response->getStatusCode()); // See Other
         $this->assertEquals($url, $response->getHeader('Location'));
         $obj = Convert::xml2array($response->getBody());
         $this->assertEquals($comment1->ID, $obj['ID']);


### PR DESCRIPTION
Fix infinite redirect after PUT by changing requestMethod through responsecode.

REST clients following the redirect after a PUT (updating a record) get into an infinite redirect loop because the request method of the redirect is the same as for the inital PUT. The request method after a PUT needs to be changed to GET by responding with a 303: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#303