### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/DataFormatter/JSONDataFormatter.php
+++ b/src/DataFormatter/JSONDataFormatter.php
@@ -52,7 +52,7 @@ class JSONDataFormatter extends DataFormatter
      */
     public function convertArray($array)
     {
-        return Convert::array2json($array);
+        return json_encode($array);
     }
 
     /**
@@ -65,7 +65,7 @@ class JSONDataFormatter extends DataFormatter
      */
     public function convertDataObject(DataObjectInterface $obj, $fields = null, $relations = null)
     {
-        return Convert::array2json($this->convertDataObjectToJSONObject($obj, $fields, $relations));
+        return json_encode($this->convertDataObjectToJSONObject($obj, $fields, $relations));
     }
 
     /**
@@ -186,7 +186,7 @@ class JSONDataFormatter extends DataFormatter
             "items" => $items
         ));
 
-        return Convert::array2json($serobj);
+        return json_encode($serobj);
     }
 
     /**
@@ -195,7 +195,7 @@ class JSONDataFormatter extends DataFormatter
      */
     public function convertStringToArray($strData)
     {
-        return Convert::json2array($strData);
+        return json_decode($strData, true);
     }
 
     public static function cast(FieldType\DBField $dbfield)

--- a/tests/unit/RestfulServerTest.php
+++ b/tests/unit/RestfulServerTest.php
@@ -307,7 +307,7 @@ class RestfulServerTest extends SapphireTest
             'Accept' => 'application/json'
         ));
         $this->assertEquals(202, $response->getStatusCode()); // Accepted
-        $obj = Convert::json2obj($response->getBody());
+        $obj = json_decode($response->getBody());
         $this->assertEquals($comment1->ID, $obj->ID);
         $this->assertEquals('updated', $obj->Comment);
 
@@ -318,7 +318,7 @@ class RestfulServerTest extends SapphireTest
         $response = Director::test($url, null, null, 'PUT', $body);
         $this->assertEquals(202, $response->getStatusCode()); // Accepted
         $this->assertEquals($url, $response->getHeader('Location'));
-        $obj = Convert::json2obj($response->getBody());
+        $obj = json_decode($response->getBody());
         $this->assertEquals($comment1->ID, $obj->ID);
         $this->assertEquals('updated', $obj->Comment);
 
@@ -368,7 +368,7 @@ class RestfulServerTest extends SapphireTest
         $headers = array('Accept' => 'application/json');
         $response = Director::test($url, null, null, 'GET', null, $headers);
         $this->assertEquals(200, $response->getStatusCode()); // Success
-        $obj = Convert::json2obj($response->getBody());
+        $obj = json_decode($response->getBody());
         $this->assertEquals($comment1->ID, $obj->ID);
         $this->assertEquals('application/json', $response->getHeader('Content-Type'));
     }
@@ -659,7 +659,7 @@ class RestfulServerTest extends SapphireTest
         $response = Director::test($url, null, null, 'GET');
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertNotContains('Unspeakable', $response->getBody());
-        $responseArray = Convert::json2array($response->getBody());
+        $responseArray = json_decode($response->getBody(), true);
         $this->assertSame(0, $responseArray['totalSize']);
 
         // With authentication


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/8424