### PR TITLE
Sanitize classname for has_one relations

### DIFF
--- a/src/DataFormatter/XMLDataFormatter.php
+++ b/src/DataFormatter/XMLDataFormatter.php
@@ -148,6 +148,8 @@ class XMLDataFormatter extends DataFormatter
                 if (!singleton($relClass)->stat('api_access')) {
                     continue;
                 }
+                // backslashes in FQCNs kills both URIs and XML
+                $relClass = $this->sanitiseClassName($relClass);
 
                 // Field filtering
                 if ($fields && !in_array($relName, $fields)) {


### PR DESCRIPTION
Sanitize the classname for has_one relations in XMLDataFormatter, to not break the XML and make the relation link work.