### PR TITLE
FIX Respect new typehints

### DIFF
--- a/src/DataFormatter/JSONDataFormatter.php
+++ b/src/DataFormatter/JSONDataFormatter.php
@@ -89,7 +89,12 @@ class JSONDataFormatter extends DataFormatter
                 continue;
             }
 
-            $fieldValue = JSONDataFormatter::cast($obj->obj($fieldName));
+            $dbField = $obj->obj($fieldName);
+            if ($dbField) {
+                $fieldValue = JSONDataFormatter::cast($dbField);
+            } else {
+                $fieldValue = null;
+            }
             $mappedFieldName = $this->getFieldAlias($className, $fieldName);
             $serobj->$mappedFieldName = $fieldValue;
         }
@@ -117,10 +122,11 @@ class JSONDataFormatter extends DataFormatter
                     ? $this->sanitiseClassName($relClass) . '/' . $obj->$fieldName
                     : $this->sanitiseClassName($className) . "/$id/$relName";
                 $href = Director::absoluteURL($rel);
+                $dbField = $obj->obj($fieldName);
                 $serobj->$relName = ArrayData::array_to_object(array(
                     "className" => $relClass,
                     "href" => "$href.json",
-                    "id" => JSONDataFormatter::cast($obj->obj($fieldName))
+                    "id" => $dbField ? JSONDataFormatter::cast($dbField): ''
                 ));
             }
 

--- a/src/DataFormatter/XMLDataFormatter.php
+++ b/src/DataFormatter/XMLDataFormatter.php
@@ -125,7 +125,7 @@ class XMLDataFormatter extends DataFormatter
             if ($fields && !in_array($fieldName, $fields ?? [])) {
                 continue;
             }
-            $fieldValue = $obj->obj($fieldName)->forTemplate();
+            $fieldValue = $obj->obj($fieldName)?->forTemplate();
             if (!mb_check_encoding($fieldValue, 'utf-8')) {
                 $fieldValue = "(data is badly encoded)";
             }


### PR DESCRIPTION
Respects the fact that `obj()` can now return `null`.
There are other places where `obj()` is called that I have intentionally not updated, either because they won't cause problems or because they shouldn't fail silently.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11322