### PR TITLE
FIX Add protection against deprecated warning from `mb_check_encoding()`

### DIFF
--- a/src/DataFormatter/XMLDataFormatter.php
+++ b/src/DataFormatter/XMLDataFormatter.php
@@ -126,7 +126,7 @@ class XMLDataFormatter extends DataFormatter
                 continue;
             }
             $fieldValue = $obj->obj($fieldName)->forTemplate();
-            if (!mb_check_encoding($fieldValue, 'utf-8')) {
+            if (isset($fieldValue) && !mb_check_encoding($fieldValue, 'utf-8')) {
                 $fieldValue = "(data is badly encoded)";
             }
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

When the `$fieldValue` is not set, the `mb_check_encoding()` function raises a deprecation warning.

```
[Deprecated] mb_check_encoding(): Calling mb_check_encoding() without argument is deprecated
```

So we make sure the field value is set before using it.

## Manual testing steps

Use the restful server to output a field which is not set

## Issues

- #123 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
