### PR TITLE
FIX Make sure the href attribute is constructed correctly when trailing slash is used

### DIFF
--- a/src/DataFormatter/XMLDataFormatter.php
+++ b/src/DataFormatter/XMLDataFormatter.php
@@ -117,9 +117,9 @@ class XMLDataFormatter extends DataFormatter
     {
         $className = $this->sanitiseClassName(get_class($obj));
         $id = $obj->ID;
-        $objHref = Director::absoluteURL($this->config()->api_base . "$className/$obj->ID");
+        $objHref = Director::absoluteURL($this->config()->api_base . "$className/$obj->ID" . ".xml");
 
-        $xml = "<$className href=\"$objHref.xml\">\n";
+        $xml = "<$className href=\"$objHref\">\n";
         foreach ($this->getFieldsForObj($obj) as $fieldName => $fieldType) {
             // Field filtering
             if ($fields && !in_array($fieldName, $fields ?? [])) {

--- a/src/DataFormatter/XMLDataFormatter.php
+++ b/src/DataFormatter/XMLDataFormatter.php
@@ -160,11 +160,11 @@ class XMLDataFormatter extends DataFormatter
 
                 $fieldName = $relName . 'ID';
                 if ($obj->$fieldName) {
-                    $href = Director::absoluteURL($this->config()->api_base . "$relClass/" . $obj->$fieldName);
+                    $href = Director::absoluteURL($this->config()->api_base . "$relClass/" . $obj->$fieldName . ".xml");
                 } else {
-                    $href = Director::absoluteURL($this->config()->api_base . "$className/$id/$relName");
+                    $href = Director::absoluteURL($this->config()->api_base . "$className/$id/$relName" . ".xml");
                 }
-                $xml .= "<$relName linktype=\"has_one\" href=\"$href.xml\" id=\"" . $obj->$fieldName
+                $xml .= "<$relName linktype=\"has_one\" href=\"$href\" id=\"" . $obj->$fieldName
                     . "\"></$relName>\n";
             }
 
@@ -190,8 +190,8 @@ class XMLDataFormatter extends DataFormatter
                 $items = $obj->$relName();
                 if ($items) {
                     foreach ($items as $item) {
-                        $href = Director::absoluteURL($this->config()->api_base . "$relClass/$item->ID");
-                        $xml .= "<$relClass href=\"$href.xml\" id=\"{$item->ID}\"></$relClass>\n";
+                        $href = Director::absoluteURL($this->config()->api_base . "$relClass/$item->ID" . ".xml");
+                        $xml .= "<$relClass href=\"$href\" id=\"{$item->ID}\"></$relClass>\n";
                     }
                 }
                 $xml .= "</$relName>\n";
@@ -221,8 +221,8 @@ class XMLDataFormatter extends DataFormatter
                 $items = $obj->$relName();
                 if ($items) {
                     foreach ($items as $item) {
-                        $href = Director::absoluteURL($this->config()->api_base . "$relClass/$item->ID");
-                        $xml .= "<$relClass href=\"$href.xml\" id=\"{$item->ID}\"></$relClass>\n";
+                        $href = Director::absoluteURL($this->config()->api_base . "$relClass/$item->ID" . ".xml");
+                        $xml .= "<$relClass href=\"$href\" id=\"{$item->ID}\"></$relClass>\n";
                     }
                 }
                 $xml .= "</$relName>\n";

--- a/tests/unit/XMLDataFormatterTest.php
+++ b/tests/unit/XMLDataFormatterTest.php
@@ -78,50 +78,30 @@ XML
     }
 
     /**
-     * Tests wrapper output of {@link XMLDataFormatter::convertDataObjectWithoutHeader()}
+     * Data provider for trailing slash configuration
      */
-    public function testConvertDataObjectWithoutHeaderClassNameAttribute(): void
+    public function trailingSlashProvider(): array
     {
-        // Create a mock object
-        $mock = DataObject::create();
-        $mock->ID = 1;
-
-        // Disable trailing slash by default
-        Controller::config()->set('add_trailing_slash', false);
-
-        // Create a formatter
-        $formatter = new XMLDataFormatter();
-
-        // Test the output
-        $expectedClass = 'SilverStripe-ORM-DataObject';
-        $expectedHref = sprintf('http://localhost/api/v1/%s/%d.xml', $expectedClass, $mock->ID);
-        $expectedOutput = sprintf(
-            '<%s href="%s"><ID>%d</ID></%s>',
-            $expectedClass,
-            $expectedHref,
-            $mock->ID,
-            $expectedClass
-        );
-
-        $actualOutput = $formatter->convertDataObjectWithoutHeader($mock);
-
-        // remove line breaks and compare
-        $actualOutput = str_replace(["\n", "\r"], '', $actualOutput);
-        $this->assertEquals($expectedOutput, $actualOutput);
+        return [
+            'without trailing slash' => [false],
+            'with trailing slash' => [true],
+        ];
     }
 
     /**
-     * Tests wrapper output of {@link XMLDataFormatter::convertDataObjectWithoutHeader()} when
-     * used with a forced trailing slash
+     * Tests wrapper output of {@link XMLDataFormatter::convertDataObjectWithoutHeader()}
+     *
+     * @param bool $addTrailingSlash - Whether to add a trailing slash to the API endpoint
+     * @dataProvider trailingSlashProvider
      */
-    public function testConvertDataObjectWithoutHeaderClassNameAttributeWithTrailingSlash(): void
+    public function testConvertDataObjectWithoutHeaderClassNameAttribute(bool $addTrailingSlash): void
     {
         // Create a mock object
         $mock = DataObject::create();
         $mock->ID = 1;
 
-        // Enable trailing slash by default
-        Controller::config()->set('add_trailing_slash', true);
+        // Set trailing slash configuration
+        Controller::config()->set('add_trailing_slash', $addTrailingSlash);
 
         // Create a formatter
         $formatter = new XMLDataFormatter();

--- a/tests/unit/XMLDataFormatterTest.php
+++ b/tests/unit/XMLDataFormatterTest.php
@@ -80,7 +80,7 @@ XML
     /**
      * Data provider for trailing slash configuration
      */
-    public function trailingSlashProvider(): array
+    public function provideConvertDataObjectWithoutHeaderClassNameAttribute(): array
     {
         return [
             'without trailing slash' => [false],

--- a/tests/unit/XMLDataFormatterTest.php
+++ b/tests/unit/XMLDataFormatterTest.php
@@ -91,8 +91,7 @@ XML
     /**
      * Tests wrapper output of {@link XMLDataFormatter::convertDataObjectWithoutHeader()}
      *
-     * @param bool $addTrailingSlash - Whether to add a trailing slash to the API endpoint
-     * @dataProvider trailingSlashProvider
+     * @dataProvider provideConvertDataObjectWithoutHeaderClassNameAttribute
      */
     public function testConvertDataObjectWithoutHeaderClassNameAttribute(bool $addTrailingSlash): void
     {


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

Just something I spotted in passing, when `Controller::add_trailing_slash` is enabled the `href` in the XML output for API responses is incorrect.

This adds a couple of tests, one to replicate the issue and fixes the issue.

The tests don't cover all usage as that would require setting up a proper stub etc. and I simply didn't have time for that. The fix should be fairly risk free.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

* Enable trailing slashes: `Controller::add_trailing_slash` = `true`
* Request an API resource using the XML formatter
* See the `href` urls are constructed correctly and don't end in `/.xml`

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #138 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
